### PR TITLE
fix(api): neutraliser endpoints Monark cassés en production

### DIFF
--- a/pages/api/monark/dashboard.ts
+++ b/pages/api/monark/dashboard.ts
@@ -1,8 +1,10 @@
-import { Souverain } from "../../../src/monark/core/souverain";
-
 export default async function handler(req, res) {
-  const souverain = new Souverain();
-  const decision = await souverain.statuer(req.body);
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
 
-  res.status(200).json(decision.dashboard);
+  return res.status(503).json({
+    error: "Monark service temporarily unavailable",
+    dashboard: null,
+  });
 }

--- a/pages/api/monark/futur.ts
+++ b/pages/api/monark/futur.ts
@@ -1,11 +1,11 @@
-import { Souverain } from "../../../src/monark/core/souverain";
-
 export default async function handler(req, res) {
-  const souverain = new Souverain();
-  const decision = await souverain.statuer(req.body);
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
 
-  res.status(200).json({
-    lignesFutur: decision.lignesFutur,
-    trajectoire: decision.trajectoire
+  return res.status(503).json({
+    error: "Monark service temporarily unavailable",
+    lignesFutur: [],
+    trajectoire: null,
   });
 }

--- a/pages/api/monark/plans.ts
+++ b/pages/api/monark/plans.ts
@@ -1,8 +1,10 @@
-import { Souverain } from "../../../src/monark/core/souverain";
-
 export default async function handler(req, res) {
-  const souverain = new Souverain();
-  const decision = await souverain.statuer(req.body);
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
 
-  res.status(200).json(decision.plans);
+  return res.status(503).json({
+    error: "Monark service temporarily unavailable",
+    plans: [],
+  });
 }


### PR DESCRIPTION
## Objectif
Supprimer la cause immédiate de l'échec Vercel sur `main` (imports Monark manquants via `Souverain`).

## Modifications
- `pages/api/monark/dashboard.ts`
- `pages/api/monark/futur.ts`
- `pages/api/monark/plans.ts`

Chaque endpoint retourne désormais un mode dégradé contrôlé (`503`) au lieu d'importer `src/monark/core/souverain`.

## Pourquoi
Le dernier build production échoue avec des `Module not found` en cascade depuis `src/monark/core/souverain/index.ts`.
Ce patch restaure la capacité de build/deploy du site principal en attendant la réintégration complète du moteur Monark.
